### PR TITLE
Set GH action with th official repo

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Check files using the black formatter
         uses: psf/black@stable
         with:
-          option: "--line-length=140"
+          options: "--line-length=140"
       - name: Create Pull Request
         if: steps.action_black.outputs.is_formatted == 'true'
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,10 +7,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Check files using the black formatter
-        uses: rickstaa/action-black@v1
-        id: action_black
+        uses: psf/black@stable
         with:
-          black_args: "--line-length 140 ."
+          option: "--line-length=140"
       - name: Create Pull Request
         if: steps.action_black.outputs.is_formatted == 'true'
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
# Motivations and context
Since Black releases an official github action, the author of the action advises to use the official one now.


## Type of change
- Code cleaning & refactoring


# Description
Use now the action `psf/black@stable`, (cf. this [link](https://black.readthedocs.io/en/stable/integrations/github_actions.html)) instead of [this one](https://github.com/rickstaa/action-black).



# Remaining TODOs before merge



# How Has This Been Tested?

# Checklist:
- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?
- [x] Did you make sure your code follows the style guidelines of this project?
- [x] Did you perform a self-review of your own code?
- [ ] Did you comment your code, particularly in hard-to-understand areas?
- [ ] Did you add tests that prove your fix is effective or that your feature works (if applicable)?
